### PR TITLE
:recycle: Refactor: setLocalStorage로 중복 로직 분리

### DIFF
--- a/frontend/static/js/views/AbstractView.js
+++ b/frontend/static/js/views/AbstractView.js
@@ -11,4 +11,27 @@ export default class AbstractView {
   async getHtml() {
     return "";
   }
+
+  setLocalStorage(id, title, coverImg, artist) {
+    localStorage.setItem(
+      "data",
+      JSON.stringify([
+        ...JSON.parse(localStorage.getItem("data") || "[]"),
+        {
+          id: id,
+          title : title,
+          coverImg: coverImg,
+          artist: artist,
+        },
+      ])
+    );
+
+    // 중복 제거하는 로직
+    if (localStorage.getItem("data") != null) {
+      let musicList = JSON.parse(localStorage.getItem("data"));
+
+      const newSetArray = [...new Set(musicList.map(JSON.stringify))].map(JSON.parse);
+      localStorage.setItem("data", JSON.stringify(newSetArray));
+    }
+  }
 }

--- a/frontend/static/js/views/PlayControl.js
+++ b/frontend/static/js/views/PlayControl.js
@@ -41,26 +41,7 @@ export default class PlayControl extends AbstractView {
         let coverImg = response.album.cover_small;
         let artist = response.artist.name;
 
-        localStorage.setItem(
-          "data",
-          JSON.stringify([
-            ...JSON.parse(localStorage.getItem("data") || "[]"),
-            {
-              id: id,
-              title: title,
-              coverImg: coverImg,
-              artist: artist,
-            },
-          ])
-        );
-
-        // 중복 제거하는 로직
-        if (localStorage.getItem("data") != null) {
-          let musicList = JSON.parse(localStorage.getItem("data"));
-
-          const newSetArray = [...new Set(musicList.map(JSON.stringify))].map(JSON.parse);
-          localStorage.setItem("data", JSON.stringify(newSetArray));
-        }
+        super.setLocalStorage(id, title, coverImg, artist);
 
         const $playControlWrapper = document.querySelector(".play-control-wrap");
 

--- a/frontend/static/js/views/Search.js
+++ b/frontend/static/js/views/Search.js
@@ -118,28 +118,8 @@ export default class Search extends AbstractView {
             let coverImg = event.currentTarget.dataset.cover;
             let artist = event.currentTarget.dataset.artist;
 
-            localStorage.setItem(
-              "data",
-              JSON.stringify([
-                ...JSON.parse(localStorage.getItem("data") || "[]"),
-                {
-                  id: id,
-                  title: title,
-                  coverImg: coverImg,
-                  artist: artist,
-                },
-              ])
-            );
-    
-            // 중복 제거하는 로직
-            if (localStorage.getItem("data") != null) {
-              let musicList = JSON.parse(localStorage.getItem("data"));
-    
-              const newSetArray = [...new Set(musicList.map(JSON.stringify))].map(JSON.parse);
-              localStorage.setItem("data", JSON.stringify(newSetArray));
-            }
+            super.setLocalStorage(id, title, coverImg, artist);
           })
-          
         })
       });
     $inputValue.value = "";


### PR DESCRIPTION
# :recycle: Refactor: setLocalStorage로 중복 로직 분리

## 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 디자인 : 
- [X] 리팩토링 : setLocalStorage로 중복 로직 분리
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- frontend/static/js/views/AbstractView.js

## 📝 생성된 파일

- 없음

## 📢 스크린샷
![image](https://user-images.githubusercontent.com/93987174/221332046-b7f2c30a-81fd-480e-9acf-35de3f0a5f20.png)

## 📌 제안 사항
- 없음

## 🍀 Close Issue Number
close: #65 
