### PR TITLE
:sparkles: Feat: search 페이지 기본 화면 이미지 추가

### DIFF
--- a/frontend/static/css/search.css
+++ b/frontend/static/css/search.css
@@ -29,3 +29,12 @@
   overflow-y: auto;
   height: calc(100vh - 14.4rem);
 }
+
+.search-default-image {
+  width: 25rem;
+  margin: 20rem auto;
+}
+
+#searchInpValue {
+  width: 100%;
+}

--- a/frontend/static/js/views/Search.js
+++ b/frontend/static/js/views/Search.js
@@ -22,11 +22,15 @@ export default class Search extends AbstractView {
     const searchForm = document.createElement("form");
     const searchInputBar = document.createElement("fieldset");
     const searchListMain = document.createElement("section");
+    const searchDefaultImage = document.createElement("img");
 
     searchForm.classList.add("search-form");
     searchTitle.classList.add("sr-only");
     searchInputBar.classList.add("search-input-bar");
     searchListMain.classList.add("searchlist-main");
+
+    searchDefaultImage.classList.add("search-default-image");
+    searchDefaultImage.setAttribute("src", "/static/image/search-default.png");
 
     const searchInputTitle = document.createElement("legend");
     const searchInpLabel = document.createElement("label");
@@ -56,7 +60,7 @@ export default class Search extends AbstractView {
     const searchMainUl = document.createElement("ul");
 
     searchInputBar.append(searchInputTitle, searchInpLabel, searchInput, searchButton);
-    searchListMain.append(searchMainTitle, searchMainUl);
+    searchListMain.append(searchMainTitle, searchMainUl, searchDefaultImage);
     searchForm.append(searchInputBar);
     searchWrapper.append(searchTitle, searchForm, searchListMain);
     wrapper.appendChild(searchWrapper);
@@ -76,13 +80,17 @@ export default class Search extends AbstractView {
     event.preventDefault();
 
     const $searchMainUl = document.querySelector("ul");
+    const $searchDefaultImage = document.querySelector(".search-default-image");
     let $inputValue = document.querySelector("#searchInpValue");
 
-    useFetch(`search?q=${$inputValue.value}`)
-      .then((response) => {
-        const searchItem = response.data
-          .map((item) => {
-            return `
+    if (!$inputValue.value) {
+      alert("검색어를 입력해주세요");
+    } else {
+      useFetch(`search?q=${$inputValue.value}`)
+        .then((response) => {
+          const searchItem = response.data
+            .map((item) => {
+              return `
             <li class="playlist-item">
               <figure class="playlist-info">
                 <img src=${item.album.cover_small} alt="앨범 타이틀">
@@ -105,23 +113,31 @@ export default class Search extends AbstractView {
               </button>
             </li>
         `;
-          })
-          .join("");
-        $searchMainUl.innerHTML = searchItem;
-        return response;
-      }).then(() => {
-        const $musicAddBtn = document.querySelectorAll(".music-add-btn");
-        $musicAddBtn.forEach((button) => {
-          button.addEventListener("click", (event) => {
-            let id = Number(event.currentTarget.dataset.id);
-            let title = event.currentTarget.dataset.title;
-            let coverImg = event.currentTarget.dataset.cover;
-            let artist = event.currentTarget.dataset.artist;
-
-            super.setLocalStorage(id, title, coverImg, artist);
-          })
+            })
+            .join("");
+          $searchMainUl.innerHTML = searchItem;
+          return response;
         })
-      });
-    $inputValue.value = "";
+        .then(() => {
+          const $musicAddBtn = document.querySelectorAll(".music-add-btn");
+          $musicAddBtn.forEach((button) => {
+            button.addEventListener("click", (event) => {
+              let id = Number(event.currentTarget.dataset.id);
+              let title = event.currentTarget.dataset.title;
+              let coverImg = event.currentTarget.dataset.cover;
+              let artist = event.currentTarget.dataset.artist;
+
+              super.setLocalStorage(id, title, coverImg, artist);
+            });
+          });
+        });
+      $inputValue.value = "";
+
+      if (!$searchDefaultImage) {
+        return;
+      } else {
+        $searchDefaultImage.remove();
+      }
+    }
   }
 }


### PR DESCRIPTION
# search 페이지 기본 화면 이미지 추가
#83 

## 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 :  search 페이지 기본화면 추가, 검색어 없을 때 검색 시 ALERT 추가,  검색 input width 100%로 수정
- [ ] 디자인 :  
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- frontend/static/css/search.csss
- frontend/static/js/views/Search.js

## 📝 생성된 파일

- 없음

## 📢 스크린샷

![image](https://user-images.githubusercontent.com/68059880/225328859-268cf478-aa72-497c-a9a0-b2faa98c9b3e.png)


## 📌 제안 사항

- 없음

## 🍀 Close Issue Number
close: #
